### PR TITLE
Fix internal links not working when API_PREFIX is not set

### DIFF
--- a/cessda_skgif_api/main.py
+++ b/cessda_skgif_api/main.py
@@ -20,15 +20,13 @@ from cessda_skgif_api.config_loader import load_config
 from cessda_skgif_api.routes.products import router as products_router
 from cessda_skgif_api.routes.topics import router as topics_router
 
-def build_api_prefix(config):
-    if config.api_prefix:
-        return f"/{config.api_prefix}"
-    else:
-        return ""
 
 config = load_config()
 api_base_url = config.api_base_url
-api_prefix = build_api_prefix(config)
+if config.api_prefix:
+    api_prefix = f"/{config.api_prefix}"
+else:
+    api_prefix = ""
 
 
 app = FastAPI(


### PR DESCRIPTION
This is caused by `/{api_prefix}/`, which when `api_prefix` is `nil` becomes `//`. This causes links to become relative to the protocol, rather than the site root.