### PR TITLE
Fix server URL formatting in FastAPI setup

### DIFF
--- a/cessda_skgif_api/main.py
+++ b/cessda_skgif_api/main.py
@@ -33,7 +33,7 @@ else:
 app = FastAPI(
     title="CESSDA Data Catalogue and ELSST SKG-IF API",
     servers=[
-        {"url": f"{api_base_url}/{api_prefix}", "description": "CESSDA SKG-IF API"},
+        {"url": f"{api_base_url}{api_prefix}", "description": "CESSDA SKG-IF API"},
     ],
     root_path=api_prefix,
     root_path_in_servers=False,


### PR DESCRIPTION
I thought I found the remaining issues with api_prefix already before but I missed this one. Matters for the dynamically generated OpenAPI documentation which will now return 404 for everything due to the extra slash.