### PR TITLE
Remove MongoDB ping on application start

### DIFF
--- a/cessda_skgif_api/db/mongodb.py
+++ b/cessda_skgif_api/db/mongodb.py
@@ -51,8 +51,6 @@ async def create_client() -> AsyncMongoClient:
         maxPoolSize=100,
         minPoolSize=1,
     )
-    # Do an early ping so startup fails fast if DB is unreachable
-    await client.admin.command("ping")
     return client
 
 


### PR DESCRIPTION
This allows the container to start and serve requests if MongoDB is unavailable.